### PR TITLE
added "

### DIFF
--- a/posts/rest.html
+++ b/posts/rest.html
@@ -70,7 +70,7 @@
     with REST. You can google them. But for Python, <a href="https://realpython.com/api-integration-in-python/">this</a>
     article is by far the best I have seen. Before you begin, make sure to check
     out the <a href="https://en.wikipedia.org/wiki/Representational_state_transfer">Wikipedia</a>
-    page on REST and pay attention to Architectural constraints. The REST <a href=https://restcookbook.com/">Cookbook</a>
+    page on REST and pay attention to Architectural constraints. The REST <a href="https://restcookbook.com/">Cookbook</a>
     can help you iron out some of the niggles people face when building
     a REST API.</p>
 


### PR DESCRIPTION
Currently it opens at https://restcookbook.com/" which gives 404 Not Found
Now, added " to the beginning of the link to match the closing "